### PR TITLE
Force resolve package manager for unity 2020 or later

### DIFF
--- a/Packages/UnityGitPackageUpdater/Editor/EditorWindows/GitPackageUpdaterEditorWindow.cs
+++ b/Packages/UnityGitPackageUpdater/Editor/EditorWindows/GitPackageUpdaterEditorWindow.cs
@@ -116,6 +116,8 @@ namespace GitPackageUpdater
             AssetDatabase.Refresh();
 #if UNITY_2020_1_OR_NEWER
             Client.Resolve();
+#else
+            Debug.LogWarning("Press 'Ctrl/Cmd+R' to force Unity Package Manager to resolve packages.");
 #endif
         }
 

--- a/Packages/UnityGitPackageUpdater/Editor/EditorWindows/GitPackageUpdaterEditorWindow.cs
+++ b/Packages/UnityGitPackageUpdater/Editor/EditorWindows/GitPackageUpdaterEditorWindow.cs
@@ -62,15 +62,13 @@ namespace GitPackageUpdater
                 if (GUILayout.Button("Update All"))
                 {
                     ReinstallAllGitPackages();
-
-                    AssetDatabase.Refresh();
+                    RefreshUnity();
                 }
 
                 if (GUILayout.Button("Update All (Including Non-Git)"))
                 {
                     File.Delete(PackagesLockPath);
-
-                    AssetDatabase.Refresh();
+                    RefreshUnity();
                 }
 
                 EditorGUILayout.HelpBox("Or select a package below to update", MessageType.Info);
@@ -92,7 +90,7 @@ namespace GitPackageUpdater
                 if (GUILayout.Button(packages[i]))
                 {
                     ReinstallPackage(packages[i]);
-                    AssetDatabase.Refresh();
+                    RefreshUnity();
                 }
             }
 
@@ -111,6 +109,14 @@ namespace GitPackageUpdater
             );
             gitPackageReinstallerWindow.Show();
             gitPackageReinstallerWindow.RefreshPackages();
+        }
+
+        private static void RefreshUnity()
+        {
+            AssetDatabase.Refresh();
+#if UNITY_2020_1_OR_NEWER
+            Client.Resolve();
+#endif
         }
 
         public void RefreshPackages()


### PR DESCRIPTION
If Unity 2020 or later calls `UnityEditor.PackageManager.Client.Resolve()` after `AssetDatabase.Refresh()` to force Package Manager to resolve packages, otherwise displays a warning log to prompt user for `Ctrl/Cmd+R`.

Not tested with Unity 2020 yet.